### PR TITLE
feat: display events from API

### DIFF
--- a/src/app/event/[hash]/page.tsx
+++ b/src/app/event/[hash]/page.tsx
@@ -2,9 +2,8 @@ import EventDetailContainer from '../_containers/EventDetailContainer'
 import { getEvent } from '../_services/actions'
 import type { EventType } from '../_containers/EventListContainer'
 
-export default async function EventDetailPage({ params }: { params: { seq: string } }) {
-
-  const event: EventType | null = await getEvent(params.seq)
+export default async function EventDetailPage({ params }: { params: { hash: string } }) {
+  const event: EventType | null = await getEvent(params.hash)
   if (!event) {
     return null
   }

--- a/src/app/event/_containers/EventDetailContainer.tsx
+++ b/src/app/event/_containers/EventDetailContainer.tsx
@@ -10,10 +10,14 @@ type Props = {
 
 const EventDetailContainer = ({ event }: Props) => {
   return (
-    <div>
+    <article>
       <h1>{event.title}</h1>
+      <time>{event.date}</time>
       {event.content && <p>{event.content}</p>}
-    </div>
+      <a href={event.link} target="_blank" rel="noopener noreferrer">
+        원문 보기
+      </a>
+    </article>
   )
 }
 

--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -1,11 +1,16 @@
 'use client'
 
 import React from 'react'
+import Link from 'next/link'
 
 export type EventType = {
-  seq: number
+  hash: number
+  link: string
   title: string
-  content?: string
+  content: string | null
+  image?: string
+  html: boolean
+  date: string
 }
 
 type Props = {
@@ -16,7 +21,10 @@ const EventListContainer = ({ events }: Props) => {
   return (
     <ul>
       {events.map((event) => (
-        <li key={event.seq}>{event.title}</li>
+        <li key={event.hash}>
+          <Link href={`/event/${event.hash}`}>{event.title}</Link>
+          <span> {event.date}</span>
+        </li>
       ))}
     </ul>
   )

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -1,12 +1,14 @@
 'use server'
 
 import { fetchSSR } from '@/app/_global/libs/utils'
+import type { EventType } from '../_containers/EventListContainer'
 
-export async function getEvents() {
+export async function getEvents(): Promise<EventType[]> {
   try {
     const res = await fetchSSR('/api/v1/events')
     if (res.ok) {
-      return await res.json()
+      const data = await res.json()
+      return data.items ?? []
     }
   } catch (err) {
     console.error(err)
@@ -14,9 +16,9 @@ export async function getEvents() {
   return []
 }
 
-export async function getEvent(seq: string) {
+export async function getEvent(hash: string): Promise<EventType | null> {
   try {
-    const res = await fetchSSR(`/api/v1/events/${seq}`)
+    const res = await fetchSSR(`/api/v1/events/${hash}`)
     if (res.ok) {
       return await res.json()
     }


### PR DESCRIPTION
## Summary
- fetch event list from `/api/v1/events`
- render event titles and dates with links
- adopt `hash` route for event details
- link event titles to internal detail pages
- show event date and source link on detail page

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a50014592c833181af9abee7c3345d