### PR TITLE
feat: improve event detail navigation

### DIFF
--- a/src/app/event/[hash]/page.tsx
+++ b/src/app/event/[hash]/page.tsx
@@ -10,3 +10,4 @@ export default async function EventDetailPage({ params }: { params: { hash: stri
   }
   return <EventDetailContainer event={event} />
 
+}

--- a/src/app/event/_containers/EventDetailContainer.tsx
+++ b/src/app/event/_containers/EventDetailContainer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import Link from 'next/link'
 
 import type { EventType } from './EventListContainer'
 
@@ -13,10 +14,22 @@ const EventDetailContainer = ({ event }: Props) => {
     <article>
       <h1>{event.title}</h1>
       <time>{event.date}</time>
-      {event.content && <p>{event.content}</p>}
-      <a href={event.link} target="_blank" rel="noopener noreferrer">
-        원문 보기
-      </a>
+      {event.content &&
+        (event.html ? (
+          <div dangerouslySetInnerHTML={{ __html: event.content }} />
+        ) : (
+          <p>{event.content}</p>
+        ))}
+      <p>
+        <a href={event.link} target="_blank" rel="noopener noreferrer">
+          원문 바로가기
+        </a>
+      </p>
+      <p>
+        <Link href="/event" target="_self">
+          목록으로
+        </Link>
+      </p>
     </article>
   )
 }

--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -22,9 +22,9 @@ const EventListContainer = ({ events }: Props) => {
     <ul>
       {events.map((event) => (
         <li key={event.hash}>
-
-          <Link href={`/event/${event.hash}`}>{event.title}</Link>
-
+          <Link href={`/event/${event.hash}`} target="_self">
+            {event.title}
+          </Link>
           <span> {event.date}</span>
         </li>
       ))}


### PR DESCRIPTION
## Summary
- ensure event list items open details in the same tab
- show event content with links for original source and returning to the list
- fix dynamic event page to render correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a54cf0015c8331afbb0101f1d4ff2c