### PR TITLE
refactor: extract event components

### DIFF
--- a/src/app/event/[hash]/page.tsx
+++ b/src/app/event/[hash]/page.tsx
@@ -1,6 +1,6 @@
 import EventDetailContainer from '../_containers/EventDetailContainer'
 import { getEvent } from '../_services/actions'
-import type { EventType } from '../_containers/EventListContainer'
+import type { EventType } from '../_types'
 
 export default async function EventDetailPage({ params }: { params: { hash: string } }) {
 

--- a/src/app/event/_components/EventDetail.tsx
+++ b/src/app/event/_components/EventDetail.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import Link from 'next/link'
+import type { EventType } from '../_types'
+
+type Props = {
+  event: EventType
+}
+
+const EventDetail = ({ event }: Props) => (
+  <article>
+    <h1>{event.title}</h1>
+    <time>{event.date}</time>
+    {event.content &&
+      (event.html ? (
+        <div dangerouslySetInnerHTML={{ __html: event.content }} />
+      ) : (
+        <p>{event.content}</p>
+      ))}
+    <p>
+      <a href={event.link} target="_blank" rel="noopener noreferrer">
+        원문 바로가기
+      </a>
+    </p>
+    <p>
+      <Link href="/event" target="_self">
+        목록으로
+      </Link>
+    </p>
+  </article>
+)
+
+export default React.memo(EventDetail)

--- a/src/app/event/_components/EventList.tsx
+++ b/src/app/event/_components/EventList.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import Link from 'next/link'
+import type { EventType } from '../_types'
+
+type Props = {
+  query: string
+  onSearch: (e: React.ChangeEvent<HTMLInputElement>) => void
+  events: EventType[]
+  page: number
+  totalPages: number
+  onPageChange: (p: number) => void
+}
+
+const EventList = ({ query, onSearch, events, page, totalPages, onPageChange }: Props) => {
+  return (
+    <>
+      <div>
+        <input
+          type="text"
+          placeholder="검색"
+          value={query}
+          onChange={onSearch}
+        />
+      </div>
+      <ul>
+        {events.map((event) => (
+          <li key={event.hash}>
+            <Link href={`/event/${event.hash}`} target="_self">
+              {event.title}
+            </Link>
+            <span> {event.date}</span>
+          </li>
+        ))}
+      </ul>
+      {totalPages > 1 && (
+        <nav>
+          <button
+            onClick={() => onPageChange(Math.max(page - 1, 1))}
+            disabled={page === 1}
+          >
+            Prev
+          </button>
+          {Array.from({ length: totalPages }).map((_, idx) => {
+            const p = idx + 1
+            return (
+              <button
+                key={p}
+                onClick={() => onPageChange(p)}
+                disabled={p === page}
+              >
+                {p}
+              </button>
+            )
+          })}
+          <button
+            onClick={() => onPageChange(Math.min(page + 1, totalPages))}
+            disabled={page === totalPages}
+          >
+            Next
+          </button>
+        </nav>
+      )}
+    </>
+  )
+}
+
+export default React.memo(EventList)

--- a/src/app/event/_containers/EventDetailContainer.tsx
+++ b/src/app/event/_containers/EventDetailContainer.tsx
@@ -1,37 +1,15 @@
 'use client'
 
 import React from 'react'
-import Link from 'next/link'
-
-import type { EventType } from './EventListContainer'
+import EventDetail from '../_components/EventDetail'
+import type { EventType } from '../_types'
 
 type Props = {
   event: EventType
 }
 
 const EventDetailContainer = ({ event }: Props) => {
-  return (
-    <article>
-      <h1>{event.title}</h1>
-      <time>{event.date}</time>
-      {event.content &&
-        (event.html ? (
-          <div dangerouslySetInnerHTML={{ __html: event.content }} />
-        ) : (
-          <p>{event.content}</p>
-        ))}
-      <p>
-        <a href={event.link} target="_blank" rel="noopener noreferrer">
-          원문 바로가기
-        </a>
-      </p>
-      <p>
-        <Link href="/event" target="_self">
-          목록으로
-        </Link>
-      </p>
-    </article>
-  )
+  return <EventDetail event={event} />
 }
 
 export default React.memo(EventDetailContainer)

--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -1,17 +1,8 @@
 'use client'
 
 import React, { useMemo, useState } from 'react'
-import Link from 'next/link'
-
-export type EventType = {
-  hash: number
-  link: string
-  title: string
-  content: string | null
-  image?: string
-  html: boolean
-  date: string
-}
+import EventList from '../_components/EventList'
+import type { EventType } from '../_types'
 
 type Props = {
   events: EventType[]
@@ -43,55 +34,19 @@ const EventListContainer = ({ events }: Props) => {
     setPage(1)
   }
 
+  const handlePageChange = (p: number) => {
+    setPage(p)
+  }
+
   return (
-    <>
-      <div>
-        <input
-          type="text"
-          placeholder="검색"
-          value={query}
-          onChange={handleSearch}
-        />
-      </div>
-      <ul>
-        {paginatedEvents.map((event) => (
-          <li key={event.hash}>
-            <Link href={`/event/${event.hash}`} target="_self">
-              {event.title}
-            </Link>
-            <span> {event.date}</span>
-          </li>
-        ))}
-      </ul>
-      {totalPages > 1 && (
-        <nav>
-          <button
-            onClick={() => setPage((p) => Math.max(p - 1, 1))}
-            disabled={page === 1}
-          >
-            Prev
-          </button>
-          {Array.from({ length: totalPages }).map((_, idx) => {
-            const p = idx + 1
-            return (
-              <button
-                key={p}
-                onClick={() => setPage(p)}
-                disabled={p === page}
-              >
-                {p}
-              </button>
-            )
-          })}
-          <button
-            onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
-            disabled={page === totalPages}
-          >
-            Next
-          </button>
-        </nav>
-      )}
-    </>
+    <EventList
+      query={query}
+      onSearch={handleSearch}
+      events={paginatedEvents}
+      page={page}
+      totalPages={totalPages}
+      onPageChange={handlePageChange}
+    />
   )
 }
 

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { fetchSSR } from '@/app/_global/libs/utils'
-import type { EventType } from '../_containers/EventListContainer'
+import type { EventType } from '../_types'
 
 export async function getEvents(): Promise<EventType[]> {
   try {

--- a/src/app/event/_types.ts
+++ b/src/app/event/_types.ts
@@ -1,0 +1,9 @@
+export type EventType = {
+  hash: number
+  link: string
+  title: string
+  content: string | null
+  image?: string
+  html: boolean
+  date: string
+}

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -1,5 +1,6 @@
-import EventListContainer, { type EventType } from './_containers/EventListContainer'
+import EventListContainer from './_containers/EventListContainer'
 import { getEvents } from './_services/actions'
+import type { EventType } from './_types'
 
 export default async function EventPage() {
 


### PR DESCRIPTION
## Summary
- create EventList and EventDetail components under event/_components
- switch event containers to use the new presentation components
- centralize EventType definition

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a571ff0ec08331b3780eaebcee6c2f