### PR TITLE
style: apply styled-components to event components

### DIFF
--- a/src/app/event/_components/EventDetail.tsx
+++ b/src/app/event/_components/EventDetail.tsx
@@ -1,13 +1,36 @@
+"use client"
+
 import React from 'react'
 import Link from 'next/link'
+import styled from 'styled-components'
 import type { EventType } from '../_types'
 
 type Props = {
   event: EventType
 }
 
+const Article = styled.article`
+  line-height: 1.6;
+
+  h1 {
+    margin-bottom: 10px;
+    font-size: 24px;
+    font-weight: 700;
+  }
+
+  time {
+    display: block;
+    margin-bottom: 20px;
+    color: #666;
+  }
+
+  p {
+    margin-top: 20px;
+  }
+`
+
 const EventDetail = ({ event }: Props) => (
-  <article>
+  <Article>
     <h1>{event.title}</h1>
     <time>{event.date}</time>
     {event.content &&
@@ -26,7 +49,7 @@ const EventDetail = ({ event }: Props) => (
         목록으로
       </Link>
     </p>
-  </article>
+  </Article>
 )
 
 export default React.memo(EventDetail)

--- a/src/app/event/_components/EventList.tsx
+++ b/src/app/event/_components/EventList.tsx
@@ -1,5 +1,8 @@
+"use client"
+
 import React from 'react'
 import Link from 'next/link'
+import styled from 'styled-components'
 import type { EventType } from '../_types'
 
 type Props = {
@@ -11,29 +14,68 @@ type Props = {
   onPageChange: (p: number) => void
 }
 
+const Wrapper = styled.div`
+  width: 100%;
+`
+
+const SearchBox = styled.div`
+  margin-bottom: 20px;
+
+  input {
+    width: 100%;
+    padding: 10px;
+    box-sizing: border-box;
+  }
+`
+
+const List = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`
+
+const Item = styled.li`
+  & + & {
+    margin-top: 10px;
+  }
+
+  span {
+    margin-left: 10px;
+    color: #666;
+  }
+`
+
+const Pagination = styled.nav`
+  margin-top: 20px;
+
+  button {
+    margin-right: 5px;
+  }
+`
+
 const EventList = ({ query, onSearch, events, page, totalPages, onPageChange }: Props) => {
   return (
-    <>
-      <div>
+    <Wrapper>
+      <SearchBox>
         <input
           type="text"
           placeholder="검색"
           value={query}
           onChange={onSearch}
         />
-      </div>
-      <ul>
+      </SearchBox>
+      <List>
         {events.map((event) => (
-          <li key={event.hash}>
+          <Item key={event.hash}>
             <Link href={`/event/${event.hash}`} target="_self">
               {event.title}
             </Link>
-            <span> {event.date}</span>
-          </li>
+            <span>{event.date}</span>
+          </Item>
         ))}
-      </ul>
+      </List>
       {totalPages > 1 && (
-        <nav>
+        <Pagination>
           <button
             onClick={() => onPageChange(Math.max(page - 1, 1))}
             disabled={page === 1}
@@ -58,9 +100,9 @@ const EventList = ({ query, onSearch, events, page, totalPages, onPageChange }: 
           >
             Next
           </button>
-        </nav>
+        </Pagination>
       )}
-    </>
+    </Wrapper>
   )
 }
 


### PR DESCRIPTION
## Summary
- refactor EventList to use styled-components for list, items and pagination
- style EventDetail article and headings via styled-components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5815ff0308331884fcc0bb112abcc