### PR TITLE
feat(event): add pagination support

### DIFF
--- a/src/app/event/_components/EventList.tsx
+++ b/src/app/event/_components/EventList.tsx
@@ -107,3 +107,4 @@ const EventList = ({ query, onSearch, events, page, totalPages, onPageChange }: 
 }
 
 export default React.memo(EventList)
+

--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -1,17 +1,18 @@
 'use client'
 
 import React, { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import EventList from '../_components/EventList'
-import type { EventType } from '../_types'
+import type { EventType, PaginationType } from '../_types'
 
 type Props = {
   events: EventType[]
+  pagination: PaginationType
 }
 
-const EventListContainer = ({ events }: Props) => {
+const EventListContainer = ({ events, pagination }: Props) => {
   const [query, setQuery] = useState('')
-  const [page, setPage] = useState(1)
-  const itemsPerPage = 10
+  const router = useRouter()
 
   const filteredEvents = useMemo(() => {
     return events.filter((event) =>
@@ -19,35 +20,25 @@ const EventListContainer = ({ events }: Props) => {
     )
   }, [events, query])
 
-  const totalPages = Math.ceil(filteredEvents.length / itemsPerPage)
-  const paginatedEvents = useMemo(
-    () =>
-      filteredEvents.slice(
-        (page - 1) * itemsPerPage,
-        page * itemsPerPage
-      ),
-    [filteredEvents, page]
-  )
-
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value)
-    setPage(1)
   }
 
   const handlePageChange = (p: number) => {
-    setPage(p)
+    router.push(`/event?page=${p}`)
   }
 
   return (
     <EventList
       query={query}
       onSearch={handleSearch}
-      events={paginatedEvents}
-      page={page}
-      totalPages={totalPages}
+      events={filteredEvents}
+      page={pagination.page}
+      totalPages={pagination.lastPage}
       onPageChange={handlePageChange}
     />
   )
 }
 
 export default React.memo(EventListContainer)
+

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -1,19 +1,22 @@
 'use server'
 
 import { fetchSSR } from '@/app/_global/libs/utils'
-import type { EventType } from '../_types'
+import type { EventType, EventListData } from '../_types'
 
-export async function getEvents(): Promise<EventType[]> {
+export async function getEvents(page: number = 1): Promise<EventListData> {
   try {
-    const res = await fetchSSR('/events')
+    const res = await fetchSSR(`/events?page=${page}`)
     if (res.ok) {
       const data = await res.json()
-      return data.items ?? []
+      return {
+        items: data.items ?? [],
+        pagination: data.pagination ?? { page, lastPage: page },
+      }
     }
   } catch (err) {
     console.error(err)
   }
-  return []
+  return { items: [], pagination: { page, lastPage: page } }
 }
 
 export async function getEvent(hash: string): Promise<EventType | null> {

--- a/src/app/event/_types.ts
+++ b/src/app/event/_types.ts
@@ -7,3 +7,13 @@ export type EventType = {
   html: boolean
   date: string
 }
+
+export type PaginationType = {
+  page: number
+  lastPage: number
+}
+
+export type EventListData = {
+  items: EventType[]
+  pagination: PaginationType
+}

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -1,9 +1,13 @@
 import EventListContainer from './_containers/EventListContainer'
 import { getEvents } from './_services/actions'
-import type { EventType } from './_types'
+import type { EventListData } from './_types'
 
-export default async function EventPage() {
+type PageProps = {
+  searchParams: { page?: string }
+}
 
-  const events: EventType[] = await getEvents()
-  return <EventListContainer events={events} />
+export default async function EventPage({ searchParams }: PageProps) {
+  const page = Number(searchParams.page) || 1
+  const { items, pagination }: EventListData = await getEvents(page)
+  return <EventListContainer events={items} pagination={pagination} />
 }


### PR DESCRIPTION
## Summary
- add pagination types and list data container
- fetch paginated event list and pass pagination to components
- navigate between pages via router push

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a591661d008331b56590e55a4bc282