### PR TITLE
fix: ensure crawler config list is derived from arrays

### DIFF
--- a/src/app/admin/crawler/_containers/CrawlerContainer.tsx
+++ b/src/app/admin/crawler/_containers/CrawlerContainer.tsx
@@ -32,7 +32,7 @@ const CrawlerContainer = () => {
   const [saving, setSaving] = useState(false)
 
   useEffect(() => {
-    if (configData) {
+    if (Array.isArray(configData)) {
       setForms(
         configData.map((cfg) => ({
           url: cfg.url ?? '',
@@ -44,6 +44,20 @@ const CrawlerContainer = () => {
           urlPrefix: cfg.urlPrefix ?? '',
         }))
       )
+    } else if (Array.isArray(configData?.data)) {
+      setForms(
+        configData.data.map((cfg) => ({
+          url: cfg.url ?? '',
+          keywords: cfg.keywords ? cfg.keywords.split('\n').join('\n') : '',
+          linkSelector: cfg.linkSelector ?? '',
+          titleSelector: cfg.titleSelector ?? '',
+          dateSelector: cfg.dateSelector ?? '',
+          contentSelector: cfg.contentSelector ?? '',
+          urlPrefix: cfg.urlPrefix ?? '',
+        }))
+      )
+    } else {
+      setForms([emptyForm])
     }
   }, [configData])
 


### PR DESCRIPTION
## Summary
- safely build crawler config forms from API response arrays

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6e28b0483319d690690cf8fe1a4