### PR TITLE
refactor: move crawler admin to server-side services

### DIFF
--- a/src/app/admin/crawler/_components/CrawlerConfigForm.tsx
+++ b/src/app/admin/crawler/_components/CrawlerConfigForm.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Input, Textarea, TableCols } from '@/app/_global/components/Forms'
 import { Button } from '@/app/_global/components/Buttons'
+import type { CrawlerConfigType } from '../_types'
 
 const Wrapper = styled.div`
   & + & {
@@ -12,16 +13,11 @@ const Wrapper = styled.div`
 
 type Props = {
   index: number
-  form: {
-    url: string
-    keywords: string
-    linkSelector: string
-    titleSelector: string
-    dateSelector: string
-    contentSelector: string
-    urlPrefix: string
-  }
-  onChange: (index: number, e: any) => void
+  form: CrawlerConfigType
+  onChange: (
+    index: number,
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
   onRemove: (index: number) => void
 }
 

--- a/src/app/admin/crawler/_containers/CrawlerContainer.tsx
+++ b/src/app/admin/crawler/_containers/CrawlerContainer.tsx
@@ -1,20 +1,16 @@
 'use client'
-import React, { useState, useCallback, useEffect } from 'react'
-import useFetch from '@/app/_global/hooks/useFetch'
+import React, { useState, useCallback } from 'react'
 import { Button } from '@/app/_global/components/Buttons'
 import CrawlerConfigForm from '../_components/CrawlerConfigForm'
+import type { CrawlerConfigType } from '../_types'
+import { saveCrawlerConfigs, setCrawlerScheduler } from '../_services/actions'
 
-type FormType = {
-  url: string
-  keywords: string
-  linkSelector: string
-  titleSelector: string
-  dateSelector: string
-  contentSelector: string
-  urlPrefix: string
+type Props = {
+  initialConfigs: CrawlerConfigType[]
+  initialScheduler: boolean
 }
 
-const emptyForm: FormType = {
+const emptyForm: CrawlerConfigType = {
   url: '',
   keywords: '',
   linkSelector: '',
@@ -24,39 +20,25 @@ const emptyForm: FormType = {
   urlPrefix: '',
 }
 
-const CrawlerContainer = () => {
-  const { data: configData } = useFetch('/api/v1/crawler/configs')
-  const { data: schedulerData } = useFetch('/api/v1/crawler/scheduler')
-  const [forms, setForms] = useState<FormType[]>([emptyForm])
-  const [scheduler, setScheduler] = useState(false)
+const CrawlerContainer = ({ initialConfigs, initialScheduler }: Props) => {
+  const [forms, setForms] = useState<CrawlerConfigType[]>(
+    initialConfigs.length ? initialConfigs : [emptyForm]
+  )
+  const [scheduler, setScheduler] = useState(initialScheduler)
   const [saving, setSaving] = useState(false)
 
-  useEffect(() => {
-    if (configData) {
-      setForms(
-        configData.map((cfg) => ({
-          url: cfg.url ?? '',
-          keywords: cfg.keywords ? cfg.keywords.split('\n').join('\n') : '',
-          linkSelector: cfg.linkSelector ?? '',
-          titleSelector: cfg.titleSelector ?? '',
-          dateSelector: cfg.dateSelector ?? '',
-          contentSelector: cfg.contentSelector ?? '',
-          urlPrefix: cfg.urlPrefix ?? '',
-        }))
+  const onChange = useCallback(
+    (
+      index: number,
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+      const { name, value } = e.target
+      setForms((prev) =>
+        prev.map((form, i) => (i === index ? { ...form, [name]: value } : form)),
       )
-    }
-  }, [configData])
-
-  useEffect(() => {
-    if (schedulerData) {
-      setScheduler(schedulerData.enabled ?? false)
-    }
-  }, [schedulerData])
-
-  const onChange = useCallback((index, e) => {
-    const { name, value } = e.target
-    setForms((prev) => prev.map((form, i) => (i === index ? { ...form, [name]: value } : form)))
-  }, [])
+    },
+    [],
+  )
 
   const addForm = useCallback(() => {
     setForms((prev) => [...prev, { ...emptyForm }])
@@ -80,11 +62,7 @@ const CrawlerContainer = () => {
         contentSelector: f.contentSelector,
         urlPrefix: f.urlPrefix,
       }))
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/crawler/configs`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
+      await saveCrawlerConfigs(body)
       alert('저장되었습니다.')
     } finally {
       setSaving(false)
@@ -94,10 +72,7 @@ const CrawlerContainer = () => {
   const toggleScheduler = useCallback(async () => {
     const enabled = !scheduler
     setScheduler(enabled)
-    await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/crawler/scheduler?enabled=${enabled}`,
-      { method: 'POST' }
-    )
+    await setCrawlerScheduler(enabled)
   }, [scheduler])
 
   return (

--- a/src/app/admin/crawler/_services/actions.ts
+++ b/src/app/admin/crawler/_services/actions.ts
@@ -1,0 +1,53 @@
+'use server'
+
+import { fetchSSR } from '@/app/_global/libs/utils'
+import type { CrawlerConfigType } from '../_types'
+
+export async function getCrawlerConfigs(): Promise<CrawlerConfigType[]> {
+  try {
+    const res = await fetchSSR('/api/v1/crawler/configs')
+    if (res.ok) {
+      const data = await res.json()
+      const list = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []
+      return list.map((cfg: any) => ({
+        url: cfg.url ?? '',
+        keywords: Array.isArray(cfg.keywords)
+          ? cfg.keywords.join('\n')
+          : cfg.keywords ?? '',
+        linkSelector: cfg.linkSelector ?? '',
+        titleSelector: cfg.titleSelector ?? '',
+        dateSelector: cfg.dateSelector ?? '',
+        contentSelector: cfg.contentSelector ?? '',
+        urlPrefix: cfg.urlPrefix ?? '',
+      }))
+    }
+  } catch (err) {
+    console.error(err)
+  }
+  return []
+}
+
+export async function getCrawlerScheduler(): Promise<boolean> {
+  try {
+    const res = await fetchSSR('/api/v1/crawler/scheduler')
+    if (res.ok) {
+      const data = await res.json()
+      return data.enabled ?? false
+    }
+  } catch (err) {
+    console.error(err)
+  }
+  return false
+}
+
+export async function saveCrawlerConfigs(configs: CrawlerConfigType[]) {
+  await fetchSSR('/api/v1/crawler/configs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(configs),
+  })
+}
+
+export async function setCrawlerScheduler(enabled: boolean) {
+  await fetchSSR(`/api/v1/crawler/scheduler?enabled=${enabled}`, { method: 'POST' })
+}

--- a/src/app/admin/crawler/_types.ts
+++ b/src/app/admin/crawler/_types.ts
@@ -1,0 +1,9 @@
+export type CrawlerConfigType = {
+  url: string
+  keywords: string
+  linkSelector: string
+  titleSelector: string
+  dateSelector: string
+  contentSelector: string
+  urlPrefix: string
+}

--- a/src/app/admin/crawler/page.tsx
+++ b/src/app/admin/crawler/page.tsx
@@ -2,13 +2,17 @@ import AdminOnlyContainer from '@/app/_global/wrappers/AdminOnlyContainer'
 import ContentBox from '@/app/_global/components/ContentBox'
 import { MainTitle } from '@/app/_global/components/TitleBox'
 import CrawlerContainer from './_containers/CrawlerContainer'
+import { getCrawlerConfigs, getCrawlerScheduler } from './_services/actions'
 
-export default function AdminCrawlerPage() {
+export default async function AdminCrawlerPage() {
+  const configs = await getCrawlerConfigs()
+  const scheduler = await getCrawlerScheduler()
+
   return (
     <AdminOnlyContainer>
       <ContentBox>
         <MainTitle border="true">크롤링 관리</MainTitle>
-        <CrawlerContainer />
+        <CrawlerContainer initialConfigs={configs} initialScheduler={scheduler} />
       </ContentBox>
     </AdminOnlyContainer>
   )


### PR DESCRIPTION
## Summary
- fetch crawler configs and scheduler via server actions
- keep form data stable and persist using server-side save and toggle calls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6e28b0483319d690690cf8fe1a4