### PR TITLE
feat: add crawler config test

### DIFF
--- a/src/app/admin/crawler/_components/CrawlerConfigForm.tsx
+++ b/src/app/admin/crawler/_components/CrawlerConfigForm.tsx
@@ -19,9 +19,10 @@ type Props = {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void
   onRemove: (index: number) => void
+  onTest: (index: number) => void
 }
 
-const CrawlerConfigForm = ({ index, form, onChange, onRemove }: Props) => {
+const CrawlerConfigForm = ({ index, form, onChange, onRemove, onTest }: Props) => {
   return (
     <Wrapper>
       <TableCols thwidth={140}>
@@ -91,6 +92,14 @@ const CrawlerConfigForm = ({ index, form, onChange, onRemove }: Props) => {
                 value={form.urlPrefix}
                 onChange={(e) => onChange(index, e)}
               />
+            </td>
+          </tr>
+          <tr>
+            <th>테스트</th>
+            <td>
+              <Button type="button" onClick={() => onTest(index)}>
+                테스트
+              </Button>
             </td>
           </tr>
           <tr>

--- a/src/app/admin/crawler/_containers/CrawlerContainer.tsx
+++ b/src/app/admin/crawler/_containers/CrawlerContainer.tsx
@@ -3,7 +3,11 @@ import React, { useState, useCallback } from 'react'
 import { Button } from '@/app/_global/components/Buttons'
 import CrawlerConfigForm from '../_components/CrawlerConfigForm'
 import type { CrawlerConfigType } from '../_types'
-import { saveCrawlerConfigs, setCrawlerScheduler } from '../_services/actions'
+import {
+  saveCrawlerConfigs,
+  setCrawlerScheduler,
+  testCrawler,
+} from '../_services/actions'
 
 type Props = {
   initialConfigs: CrawlerConfigType[]
@@ -47,6 +51,19 @@ const CrawlerContainer = ({ initialConfigs, initialScheduler }: Props) => {
   const removeForm = useCallback((index) => {
     setForms((prev) => prev.filter((_, i) => i !== index))
   }, [])
+
+  const onTest = useCallback(
+    async (index: number) => {
+      try {
+        const result = await testCrawler(forms[index])
+        alert(result ? JSON.stringify(result, null, 2) : '테스트 실패')
+      } catch (err) {
+        console.error(err)
+        alert('테스트 실패')
+      }
+    },
+    [forms],
+  )
 
   const save = useCallback(async () => {
     setSaving(true)
@@ -96,6 +113,7 @@ const CrawlerContainer = ({ initialConfigs, initialScheduler }: Props) => {
           form={form}
           onChange={onChange}
           onRemove={removeForm}
+          onTest={onTest}
         />
       ))}
 

--- a/src/app/admin/crawler/_services/actions.ts
+++ b/src/app/admin/crawler/_services/actions.ts
@@ -51,3 +51,33 @@ export async function saveCrawlerConfigs(configs: CrawlerConfigType[]) {
 export async function setCrawlerScheduler(enabled: boolean) {
   await fetchSSR(`/crawler/scheduler?enabled=${enabled}`, { method: 'POST' })
 }
+
+export async function testCrawler(config: CrawlerConfigType) {
+  try {
+    const body = {
+      url: config.url,
+      keywords: config.keywords
+        ? config.keywords
+            .split('\n')
+            .map((k) => k.trim())
+            .filter(Boolean)
+        : [],
+      linkSelector: config.linkSelector,
+      titleSelector: config.titleSelector,
+      dateSelector: config.dateSelector,
+      contentSelector: config.contentSelector,
+      urlPrefix: config.urlPrefix,
+    }
+    const res = await fetchSSR('/crawler/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (res.ok) {
+      return await res.json()
+    }
+  } catch (err) {
+    console.error(err)
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- allow testing crawler configuration via new backend call
- add per-form test button on admin crawler page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69d29147883319757f1ed79c880df