### PR TITLE
Normalize crawler config keyword handling

### DIFF
--- a/src/app/admin/crawler/_containers/CrawlerContainer.tsx
+++ b/src/app/admin/crawler/_containers/CrawlerContainer.tsx
@@ -68,18 +68,7 @@ const CrawlerContainer = ({ initialConfigs, initialScheduler }: Props) => {
   const save = useCallback(async () => {
     setSaving(true)
     try {
-      const body = forms.map((f) => ({
-        url: f.url,
-        keywords: f.keywords
-          ? f.keywords.split('\n').map((k) => k.trim()).filter(Boolean)
-          : [],
-        linkSelector: f.linkSelector,
-        titleSelector: f.titleSelector,
-        dateSelector: f.dateSelector,
-        contentSelector: f.contentSelector,
-        urlPrefix: f.urlPrefix,
-      }))
-      await saveCrawlerConfigs(body)
+      await saveCrawlerConfigs(forms)
       alert('저장되었습니다.')
     } finally {
       setSaving(false)

--- a/src/app/admin/crawler/_services/actions.ts
+++ b/src/app/admin/crawler/_services/actions.ts
@@ -41,10 +41,20 @@ export async function getCrawlerScheduler(): Promise<boolean> {
 }
 
 export async function saveCrawlerConfigs(configs: CrawlerConfigType[]) {
+  const payload = configs.map((config) => ({
+    ...config,
+    keywords: config.keywords
+      ? config.keywords
+          .split('\n')
+          .map((k) => k.trim())
+          .filter(Boolean)
+      : [],
+  }))
+
   await fetchSSR('/crawler/configs', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(configs),
+    body: JSON.stringify(payload),
   })
 }
 


### PR DESCRIPTION
## Summary
- map crawler keywords to arrays when saving configs
- simplify crawler container save handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6f8396db48331a9d802bec2e3c7e7