### PR TITLE
Implement Kakao social login callback

### DIFF
--- a/src/app/member/social/[channel]/callback/route.ts
+++ b/src/app/member/social/[channel]/callback/route.ts
@@ -1,8 +1,35 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
+import KakaoApi from '../../_services/KakaoApi'
 
-export async function GET(request: NextRequest) {
-  console.log('유입')
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { channel: string } },
+) {
+  const { searchParams } = new URL(request.url)
+  const code = searchParams.get('code')
+  const state = searchParams.get('state') || '/'
 
-  return NextResponse.json({})
+  if (!code) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  const origin = request.headers.get('origin') || ''
+
+  let profileId = ''
+
+  switch (params.channel) {
+    case 'kakao': {
+      const api = new KakaoApi(process.env.NEXT_PUBLIC_KAKAO_API_KEY, origin)
+      const token = await api.getToken(code)
+      const profile = await api.getProfile(token)
+      profileId = profile.id.toString()
+      break
+    }
+    default:
+      return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  const redirectUrl = `${origin}/member/join?channel=${params.channel}&token=${profileId}&redirectUrl=${state}`
+  return NextResponse.redirect(redirectUrl)
 }

--- a/src/app/member/social/_services/KakaoApi.ts
+++ b/src/app/member/social/_services/KakaoApi.ts
@@ -1,18 +1,32 @@
-'use client'
 import SocialApi, { ProfileType } from './SocialApi'
 
 export default class KakaoApi implements SocialApi {
   constructor(
     private apiKey: string | undefined = process.env.NEXT_PUBLIC_KAKAO_API_KEY,
-    private domain: string = location.origin,
+    private domain: string = typeof window !== 'undefined' ? window.location.origin : '',
   ) {}
 
-  getToken(code: string) {
-    return ''
+  async getToken(code: string) {
+    const response = await fetch('https://kauth.kakao.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: this.apiKey ?? '',
+        redirect_uri: `${this.domain}/member/social/kakao/callback`,
+        code,
+      }).toString(),
+    })
+    const data = await response.json()
+    return data.access_token as string
   }
 
-  getProfile(token: string) {
-    return { id: '' }
+  async getProfile(token: string) {
+    const response = await fetch('https://kapi.kakao.com/v2/user/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const data = await response.json()
+    return { id: data.id } as ProfileType
   }
 
   getUrl(redirectUrl: string = '/') {

--- a/src/app/member/social/_services/SocialApi.ts
+++ b/src/app/member/social/_services/SocialApi.ts
@@ -8,7 +8,7 @@ export default interface SocialApi {
    * @param code : authorization code
    * @returns
    */
-  getToken: (code: string) => string
+  getToken: (code: string) => Promise<string>
 
   /**
    * 회원의 프로필 정보
@@ -16,7 +16,7 @@ export default interface SocialApi {
    * @param token : access token
    * @returns
    */
-  getProfile: (token: string) => ProfileType
+  getProfile: (token: string) => Promise<ProfileType>
 
   /**
    * 인증 서버에서 client_id를 통해서 authorization code를 발급받을 수 있는


### PR DESCRIPTION
## Summary
- implement Kakao OAuth token and profile retrieval
- handle social login callback and redirect to join page
- update SocialApi to use async methods

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Type error in src/app/event/[hash]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ad9790248331b855e826d4a74969