### PR TITLE
feat: prevent saving empty crawler configs

### DIFF
--- a/src/app/admin/crawler/_containers/CrawlerContainer.tsx
+++ b/src/app/admin/crawler/_containers/CrawlerContainer.tsx
@@ -66,9 +66,17 @@ const CrawlerContainer = ({ initialConfigs, initialScheduler }: Props) => {
   )
 
   const save = useCallback(async () => {
+    const validForms = forms.filter((form) =>
+      Object.values(form).some((value) => value.trim()),
+    )
+    if (!validForms.length) {
+      alert('입력값이 없습니다.')
+      return
+    }
+
     setSaving(true)
     try {
-      await saveCrawlerConfigs(forms)
+      await saveCrawlerConfigs(validForms)
       alert('저장되었습니다.')
     } finally {
       setSaving(false)

--- a/src/app/admin/crawler/_services/actions.ts
+++ b/src/app/admin/crawler/_services/actions.ts
@@ -41,15 +41,21 @@ export async function getCrawlerScheduler(): Promise<boolean> {
 }
 
 export async function saveCrawlerConfigs(configs: CrawlerConfigType[]) {
-  const payload = configs.map((config) => ({
-    ...config,
-    keywords: config.keywords
-      ? config.keywords
-          .split('\n')
-          .map((k) => k.trim())
-          .filter(Boolean)
-      : [],
-  }))
+  const payload = configs
+    .filter((config) =>
+      Object.values(config).some((value) => value.trim()),
+    )
+    .map((config) => ({
+      ...config,
+      keywords: config.keywords
+        ? config.keywords
+            .split('\n')
+            .map((k) => k.trim())
+            .filter(Boolean)
+        : [],
+    }))
+
+  if (!payload.length) return
 
   await fetchSSR('/crawler/configs', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- avoid saving crawler configs when no input provided
- filter empty forms before posting configs to server

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d02c5374833199f5cd9c703dee9a