### PR TITLE
feat: display event images on detail page

### DIFF
--- a/src/app/event/_components/EventDetail.tsx
+++ b/src/app/event/_components/EventDetail.tsx
@@ -27,29 +27,49 @@ const Article = styled.article`
   p {
     margin-top: 20px;
   }
+
+  img {
+    max-width: 100%;
+    display: block;
+    margin-top: 20px;
+  }
 `
 
-const EventDetail = ({ event }: Props) => (
-  <Article>
-    <h1>{event.title}</h1>
-    <time>{event.date}</time>
-    {event.content &&
-      (event.html ? (
-        <div dangerouslySetInnerHTML={{ __html: event.content }} />
-      ) : (
-        <p>{event.content}</p>
-      ))}
-    <p>
-      <a href={event.link} target="_blank" rel="noopener noreferrer">
-        원문 바로가기
-      </a>
-    </p>
-    <p>
-      <Link href="/event" target="_self">
-        목록으로
-      </Link>
-    </p>
-  </Article>
-)
+const EventDetail = ({ event }: Props) => {
+  const imageSrc = event.image
+    ? event.image.startsWith('http')
+      ? event.image
+      : new URL(event.image, event.link).href
+    : null
+
+  return (
+    <Article>
+      <h1>{event.title}</h1>
+      <time>{event.date}</time>
+      {imageSrc && (
+        <p>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={imageSrc} alt={event.title} />
+        </p>
+      )}
+      {event.content &&
+        (event.html ? (
+          <div dangerouslySetInnerHTML={{ __html: event.content }} />
+        ) : (
+          <p>{event.content}</p>
+        ))}
+      <p>
+        <a href={event.link} target="_blank" rel="noopener noreferrer">
+          원문 바로가기
+        </a>
+      </p>
+      <p>
+        <Link href="/event" target="_self">
+          목록으로
+        </Link>
+      </p>
+    </Article>
+  )
+}
 
 export default React.memo(EventDetail)


### PR DESCRIPTION
## Summary
- show event image on event detail page
- avoid lint warning for inline image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a94e2ab66483319233798f05dcd4bc