### PR TITLE
feat: apply updated pagination to event list

### DIFF
--- a/src/app/event/_components/EventList.tsx
+++ b/src/app/event/_components/EventList.tsx
@@ -12,8 +12,7 @@ type Props = {
   query: string
   onSearch: (e: React.ChangeEvent<HTMLInputElement>) => void
   events: EventType[]
-  page: number
-  totalPages: number
+  pagination: any
   onPageChange: (p: number) => void
 }
 
@@ -87,8 +86,7 @@ const EventList = ({
   query,
   onSearch,
   events,
-  page,
-  totalPages,
+  pagination,
   onPageChange,
 }: Props) => {
   return (
@@ -115,11 +113,7 @@ const EventList = ({
           ))
         )}
       </List>
-      <Pagination
-        page={page}
-        totalPages={totalPages}
-        onPageChange={onPageChange}
-      />
+      <Pagination pagination={pagination} onClick={onPageChange} />
     </Wrapper>
   )
 }

--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -25,6 +25,32 @@ const EventListContainer = ({ events }: Props) => {
     [filteredEvents, page],
   )
 
+  const createPagination = (
+    current: number,
+    last: number,
+    range = 10,
+  ) => {
+    const start = Math.floor((current - 1) / range) * range + 1
+    const end = Math.min(start + range - 1, last)
+    const pages = [] as Array<[string, string]>
+    for (let i = start; i <= end; i++) {
+      pages.push([i.toString(), '#'])
+    }
+    return {
+      pages,
+      page: current,
+      prevRangePage: start > 1 ? start - 1 : 0,
+      nextRangePage: end < last ? end + 1 : 0,
+      lastPage: last,
+      baseUrl: '#',
+    }
+  }
+
+  const pagination = useMemo(
+    () => createPagination(page, totalPages),
+    [page, totalPages],
+  )
+
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value)
     setPage(1)
@@ -39,8 +65,7 @@ const EventListContainer = ({ events }: Props) => {
       query={query}
       onSearch={handleSearch}
       events={paginatedEvents}
-      page={page}
-      totalPages={totalPages}
+      pagination={pagination}
       onPageChange={handlePageChange}
     />
   )


### PR DESCRIPTION
## Summary
- adjust event listing to consume new Pagination component
- generate client-side pagination metadata for events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac411197a48331920a94402a776e38