### PR TITLE
fix: send board config form data

### DIFF
--- a/src/app/admin/board/_services/actions.ts
+++ b/src/app/admin/board/_services/actions.ts
@@ -38,9 +38,9 @@ export async function processBoardConfig(errors, formData: FormData) {
   const res = await fetchSSR('/board/update/config', {
     method: params.mode === 'update' ? 'PATCH' : 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: JSON.stringify(params),
+    body: new URLSearchParams(params),
   })
 
   // 처리 실패시


### PR DESCRIPTION
## Summary
- submit board config using URL-encoded form data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf16d4a14833185324f0fd3b5d106