### PR TITLE
feat: use backend pagination for events

### DIFF
--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -1,17 +1,18 @@
 'use client'
 
 import React, { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import EventList from '../_components/EventList'
-import type { EventType } from '../_types'
+import type { EventType, PaginationType } from '../_types'
 
 type Props = {
   events: EventType[]
+  pagination: PaginationType
 }
 
-const EventListContainer = ({ events }: Props) => {
+const EventListContainer = ({ events, pagination }: Props) => {
   const [query, setQuery] = useState('')
-  const [page, setPage] = useState(1)
-  const itemsPerPage = 4
+  const router = useRouter()
 
   const filteredEvents = useMemo(() => {
     return events.filter((event) =>
@@ -19,52 +20,19 @@ const EventListContainer = ({ events }: Props) => {
     )
   }, [events, query])
 
-  const totalPages = Math.ceil(filteredEvents.length / itemsPerPage)
-  const paginatedEvents = useMemo(
-    () => filteredEvents.slice((page - 1) * itemsPerPage, page * itemsPerPage),
-    [filteredEvents, page],
-  )
-
-  const createPagination = (
-    current: number,
-    last: number,
-    range = 10,
-  ) => {
-    const start = Math.floor((current - 1) / range) * range + 1
-    const end = Math.min(start + range - 1, last)
-    const pages = [] as Array<[string, string]>
-    for (let i = start; i <= end; i++) {
-      pages.push([i.toString(), '#'])
-    }
-    return {
-      pages,
-      page: current,
-      prevRangePage: start > 1 ? start - 1 : 0,
-      nextRangePage: end < last ? end + 1 : 0,
-      lastPage: last,
-      baseUrl: '#',
-    }
-  }
-
-  const pagination = useMemo(
-    () => createPagination(page, totalPages),
-    [page, totalPages],
-  )
-
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value)
-    setPage(1)
   }
 
   const handlePageChange = (p: number) => {
-    setPage(p)
+    router.push(`/event?page=${p}`)
   }
 
   return (
     <EventList
       query={query}
       onSearch={handleSearch}
-      events={paginatedEvents}
+      events={filteredEvents}
       pagination={pagination}
       onPageChange={handlePageChange}
     />

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -1,19 +1,18 @@
 'use server'
 
 import { fetchSSR } from '@/app/_global/libs/utils'
-import type { EventType } from '../_types'
+import type { EventListDataType } from '../_types'
 
-export async function getEvents() {
+export async function getEvents(page = 1): Promise<EventListDataType> {
   try {
-    const res = await fetchSSR('/events')
+    const res = await fetchSSR(`/events?page=${page}`)
     if (res.ok) {
-      const data = await res.json()
-      return data.items ?? []
+      return await res.json()
     }
   } catch (err) {
     console.error(err)
   }
-  return []
+  return { items: [], pagination: { pages: [], page: 1, prevRangePage: 0, nextRangePage: 0, lastPage: 1, baseUrl: '' } }
 }
 
 export async function getEvent(hash: string) {

--- a/src/app/event/_types.ts
+++ b/src/app/event/_types.ts
@@ -7,3 +7,17 @@ export type EventType = {
   html: boolean
   date: string
 }
+
+export type PaginationType = {
+  pages: Array<[string, string]>
+  page: number
+  prevRangePage: number
+  nextRangePage: number
+  lastPage: number
+  baseUrl: string
+}
+
+export type EventListDataType = {
+  items: EventType[]
+  pagination: PaginationType
+}

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -1,14 +1,18 @@
-import type { EventType } from './_types'
 import { getEvents } from './_services/actions'
 import { MainTitle } from '../_global/components/TitleBox'
 import EventListContainer from './_containers/EventListContainer'
 
-export default async function EventPage() {
-  const events: EventType[] = await getEvents()
+export default async function EventPage({
+  searchParams,
+}: {
+  searchParams: { page?: string }
+}) {
+  const page = Number(searchParams?.page) || 1
+  const { items: events, pagination } = await getEvents(page)
   return (
     <div className="layout-width">
       <MainTitle border="true">환경 행사</MainTitle>
-      <EventListContainer events={events} />
+      <EventListContainer events={events} pagination={pagination} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- fetch events with pagination info from backend
- wire event page to server pagination

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad205854748331a64b44fb0bbf89fd