### PR TITLE
feat: limit event page to five items

### DIFF
--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -8,9 +8,10 @@ import type { EventType, PaginationType } from '../_types'
 type Props = {
   events: EventType[]
   pagination: PaginationType
+  limit?: number
 }
 
-const EventListContainer = ({ events, pagination }: Props) => {
+const EventListContainer = ({ events, pagination, limit = 5 }: Props) => {
   const [query, setQuery] = useState('')
   const router = useRouter()
 
@@ -25,7 +26,7 @@ const EventListContainer = ({ events, pagination }: Props) => {
   }
 
   const handlePageChange = (p: number) => {
-    router.push(`/event?page=${p}`)
+    router.push(`/event?page=${p}&limit=${limit}`)
   }
 
   return (

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -3,9 +3,12 @@
 import { fetchSSR } from '@/app/_global/libs/utils'
 import type { EventListDataType } from '../_types'
 
-export async function getEvents(page = 1): Promise<EventListDataType> {
+export async function getEvents(
+  page = 1,
+  limit = 5,
+): Promise<EventListDataType> {
   try {
-    const res = await fetchSSR(`/events?page=${page}`)
+    const res = await fetchSSR(`/events?page=${page}&limit=${limit}`)
     if (res.ok) {
       return await res.json()
     }

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -5,14 +5,19 @@ import EventListContainer from './_containers/EventListContainer'
 export default async function EventPage({
   searchParams,
 }: {
-  searchParams: { page?: string }
+  searchParams: { page?: string; limit?: string }
 }) {
   const page = Number(searchParams?.page) || 1
-  const { items: events, pagination } = await getEvents(page)
+  const limit = Number(searchParams?.limit) || 5
+  const { items: events, pagination } = await getEvents(page, limit)
   return (
     <div className="layout-width">
       <MainTitle border="true">환경 행사</MainTitle>
-      <EventListContainer events={events} pagination={pagination} />
+      <EventListContainer
+        events={events}
+        pagination={pagination}
+        limit={limit}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show five events per page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad6f0ab62483318d726f1f4251b9fd