### PR TITLE
refactor: use CommonSearchType for event list

### DIFF
--- a/src/app/event/_containers/EventListContainer.tsx
+++ b/src/app/event/_containers/EventListContainer.tsx
@@ -1,38 +1,42 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import EventList from '../_components/EventList'
 import type { EventType, PaginationType } from '../_types'
+import type CommonSearchType from '@/app/_global/types/CommonSearchType'
 
 type Props = {
   events: EventType[]
   pagination: PaginationType
+  search?: CommonSearchType
 }
 
-const EventListContainer = ({ events, pagination }: Props) => {
-  const [query, setQuery] = useState('')
+const EventListContainer = ({ events, pagination, search }: Props) => {
+  const [query, setQuery] = useState(search?.skey ?? '')
   const router = useRouter()
 
-  const filteredEvents = useMemo(() => {
-    return events.filter((event) =>
-      event.title.toLowerCase().includes(query.toLowerCase()),
-    )
-  }, [events, query])
-
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setQuery(e.target.value)
+    const value = e.target.value
+    setQuery(value)
+    const params = new URLSearchParams()
+    if (value) params.set('skey', value)
+    params.set('page', '1')
+    router.push(`/event?${params.toString()}`)
   }
 
   const handlePageChange = (p: number) => {
-    router.push(`/event?page=${p}`)
+    const params = new URLSearchParams()
+    if (query) params.set('skey', query)
+    params.set('page', String(p))
+    router.push(`/event?${params.toString()}`)
   }
 
   return (
     <EventList
       query={query}
       onSearch={handleSearch}
-      events={filteredEvents}
+      events={events}
       pagination={pagination}
       onPageChange={handlePageChange}
     />

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -1,18 +1,40 @@
 'use server'
 
 import { fetchSSR } from '@/app/_global/libs/utils'
+import type CommonSearchType from '@/app/_global/types/CommonSearchType'
 import type { EventListDataType } from '../_types'
 
-export async function getEvents(page = 1): Promise<EventListDataType> {
+export async function getEvents(
+  search: CommonSearchType = {},
+): Promise<EventListDataType> {
   try {
-    const res = await fetchSSR(`/events?page=${page}`)
+    const params = new URLSearchParams()
+    if (search.page) params.set('page', String(search.page))
+    if (search.sopt) params.set('sopt', search.sopt)
+    if (search.skey) params.set('skey', search.skey)
+    if (search.sdate) params.set('sDate', search.sdate)
+    if (search.edate) params.set('eDate', search.edate)
+    if (search.limit) params.set('limit', String(search.limit))
+
+    const query = params.toString()
+    const res = await fetchSSR(`/events${query ? `?${query}` : ''}`)
     if (res.ok) {
       return await res.json()
     }
   } catch (err) {
     console.error(err)
   }
-  return { items: [], pagination: { pages: [], page: 1, prevRangePage: 0, nextRangePage: 0, lastPage: 1, baseUrl: '' } }
+  return {
+    items: [],
+    pagination: {
+      pages: [],
+      page: 1,
+      prevRangePage: 0,
+      nextRangePage: 0,
+      lastPage: 1,
+      baseUrl: '',
+    },
+  }
 }
 
 export async function getEvent(hash: string) {

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -1,18 +1,25 @@
 import { getEvents } from './_services/actions'
 import { MainTitle } from '../_global/components/TitleBox'
 import EventListContainer from './_containers/EventListContainer'
+import type CommonSearchType from '../_global/types/CommonSearchType'
 
 export default async function EventPage({
   searchParams,
 }: {
-  searchParams: { page?: string }
+  searchParams: { [key: string]: string | string[] | undefined }
 }) {
-  const page = Number(searchParams?.page) || 1
-  const { items: events, pagination } = await getEvents(page)
+  const search: CommonSearchType = {
+    page: Number(searchParams?.page as string) || 1,
+    sopt: searchParams?.sopt as string,
+    skey: searchParams?.skey as string,
+    sdate: searchParams?.sdate as string,
+    edate: searchParams?.edate as string,
+  }
+  const { items: events, pagination } = await getEvents(search)
   return (
     <div className="layout-width">
       <MainTitle border="true">환경 행사</MainTitle>
-      <EventListContainer events={events} pagination={pagination} />
+      <EventListContainer events={events} pagination={pagination} search={search} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- switch event fetching to CommonSearchType-based query params
- delegate search and pagination to backend
- simplify event list container to use server data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad6f0ab62483318d726f1f4251b9fd