### PR TITLE
feat: add reusable error page

### DIFF
--- a/src/app/_global/components/ErrorPage.tsx
+++ b/src/app/_global/components/ErrorPage.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link from 'next/link'
+import styled from 'styled-components'
+import { Button } from './Buttons'
+
+interface ErrorPageProps {
+  statusCode?: number
+  title: string
+  description?: string
+}
+
+const Wrapper = styled.section`
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 40px 16px;
+  text-align: center;
+
+  h1 {
+    font-size: 4rem;
+    margin: 0 0 20px;
+  }
+
+  h2 {
+    margin: 0 0 10px;
+  }
+
+  p {
+    margin: 0 0 30px;
+  }
+`
+
+export default function ErrorPage({ statusCode, title, description }: ErrorPageProps) {
+  return (
+    <Wrapper>
+      {statusCode && <h1>{statusCode}</h1>}
+      <h2>{title}</h2>
+      {description && <p>{description}</p>}
+      <Link href="/" passHref legacyBehavior>
+        <Button as="a" type="button" center>
+          홈으로 이동
+        </Button>
+      </Link>
+    </Wrapper>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,11 @@
+import ErrorPage from './_global/components/ErrorPage'
+
 export default function NotFound() {
-  return <h1>페이지를 찾을 수 없습니다.</h1>
+  return (
+    <ErrorPage
+      statusCode={404}
+      title="페이지를 찾을 수 없습니다."
+      description="요청하신 페이지가 존재하지 않습니다."
+    />
+  )
 }


### PR DESCRIPTION
## Summary
- add reusable ErrorPage component with home navigation
- show 404 message via ErrorPage

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae646624848331b26daf9280421c73