### PR TITLE
feat: add auth and permission error pages

### DIFF
--- a/src/app/_global/components/ErrorPage.tsx
+++ b/src/app/_global/components/ErrorPage.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import ContentBox from './ContentBox'
+import { MainTitle } from './TitleBox'
+
+interface ErrorPageProps {
+  status: number
+  message: string
+}
+
+export default function ErrorPage({ status, message }: ErrorPageProps) {
+  return (
+    <ContentBox width={420}>
+      <MainTitle center="true">{status}</MainTitle>
+      <p>{message}</p>
+    </ContentBox>
+  )
+}

--- a/src/app/_global/libs/utils.ts
+++ b/src/app/_global/libs/utils.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { cookies } from 'next/headers'
+import { forbidden, unauthorized } from 'next/navigation'
 
 /**
  * token 쿠키값 조회
@@ -31,7 +32,14 @@ export async function fetchSSR(url, options: RequestInit = {}) {
     options.headers['User-Hash'] = userHash
   }
 
-  return fetch(`${process.env.API_URL}${url}`, options)
+  const res = await fetch(`${process.env.API_URL}${url}`, options)
+  if (res.status === 401) {
+    unauthorized()
+  }
+  if (res.status === 403) {
+    forbidden()
+  }
+  return res
 }
 
 export async function toQueryString(search) {

--- a/src/app/_global/wrappers/AdminOnlyContainer.tsx
+++ b/src/app/_global/wrappers/AdminOnlyContainer.tsx
@@ -1,11 +1,11 @@
 'use client'
-import { unauthorized } from 'next/navigation'
+import { forbidden } from 'next/navigation'
 import useUser from '../hooks/useUser'
 
 export default function AdminOnlyContainer({ children }) {
   const { isAdmin } = useUser()
   if (!isAdmin) {
-    unauthorized()
+    forbidden()
   }
 
   return children

--- a/src/app/_global/wrappers/UserOnlyContainer.tsx
+++ b/src/app/_global/wrappers/UserOnlyContainer.tsx
@@ -1,23 +1,12 @@
 'use client'
-import { useSearchParams, usePathname } from 'next/navigation'
+import { unauthorized } from 'next/navigation'
 import useUser from '../hooks/useUser'
-import ContentBox from '../components/ContentBox'
-import { MainTitle } from '../components/TitleBox'
-import LoginContainer from '@/app/member/_containers/LoginContainer'
+
 export default function UserOnlyContainer({ children }) {
   const { isLogin } = useUser()
-  const searchParams = useSearchParams()
-  const pathname = usePathname()
-  let qs = searchParams.toString() ?? ''
-  qs = qs ? `?${qs}` : qs
-  const redirectUrl = `${pathname}${qs}`
+  if (!isLogin) {
+    unauthorized()
+  }
 
-  return isLogin ? (
-    children
-  ) : (
-    <ContentBox width={420}>
-      <MainTitle center="true">로그인</MainTitle>
-      <LoginContainer redirectUrl={redirectUrl} />
-    </ContentBox>
-  )
+  return children
 }

--- a/src/app/forbidden.tsx
+++ b/src/app/forbidden.tsx
@@ -1,0 +1,5 @@
+import ErrorPage from './_global/components/ErrorPage'
+
+export default function Forbidden() {
+  return <ErrorPage status={403} message="접근 권한이 없습니다." />
+}

--- a/src/app/unauthorized.tsx
+++ b/src/app/unauthorized.tsx
@@ -1,3 +1,5 @@
+import ErrorPage from './_global/components/ErrorPage'
+
 export default function Unauthorized() {
-  return <h1>접근 권한이 없습니다.</h1>
+  return <ErrorPage status={401} message="로그인이 필요한 페이지입니다." />
 }


### PR DESCRIPTION
## Summary
- add reusable `ErrorPage` component
- implement dedicated 401 and 403 pages
- redirect unauthorized and forbidden access via wrappers and server utils

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae646cd1d48331888f6b52e138628f