### PR TITLE
Fix home navigation button on error pages

### DIFF
--- a/src/app/_global/components/ErrorPage.tsx
+++ b/src/app/_global/components/ErrorPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import styled from 'styled-components'
 import ContentBox from './ContentBox'
 import { Button } from './Buttons'
@@ -11,7 +11,6 @@ interface ErrorPageProps {
   statusCode: number | string
   title: string
   description?: string
-  message: string
 }
 
 const Wrapper = styled.div`
@@ -39,7 +38,6 @@ export default function ErrorPage({
   title,
   description,
 }: ErrorPageProps) {
-  const router = useRouter()
 
   return (
     <ContentBox>
@@ -47,7 +45,9 @@ export default function ErrorPage({
         <StatusCode>{statusCode}</StatusCode>
         <Title>{title}</Title>
         {description && <Description>{description}</Description>}
-        <Button type="button" onClick={() => router.push('/')}>홈으로 이동</Button>
+        <Link href="/">
+          <Button as="a">홈으로 이동</Button>
+        </Link>
       </Wrapper>
     </ContentBox>
   )


### PR DESCRIPTION
## Summary
- use Next.js Link for the home navigation button in error page
- remove unused message prop from ErrorPage component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aee0d7d8e08331aa60ab19541b0b21