### PR TITLE
chore(event): add explicit types

### DIFF
--- a/src/app/event/[hash]/page.tsx
+++ b/src/app/event/[hash]/page.tsx
@@ -3,7 +3,11 @@ import { MainTitle } from '../../_global/components/TitleBox'
 import { getEvent } from '../_services/actions'
 import type { EventType } from '../_types'
 
-export default async function EventDetailPage({ params }) {
+export default async function EventDetailPage({
+  params,
+}: {
+  params: Promise<{ hash: string }>
+}): Promise<JSX.Element | null> {
   const { hash } = await params
   const event: EventType | null = await getEvent(hash)
 

--- a/src/app/event/_components/EventList.tsx
+++ b/src/app/event/_components/EventList.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import Link from 'next/link'
 import styled from 'styled-components'
-import type { EventType } from '../_types'
+import type { EventType, PaginationType } from '../_types'
 import color from '@/app/_global/styles/color'
 import fontsize from '@/app/_global/styles/fontsize'
 import Pagination from '@/app/_global/components/Pagination'
@@ -13,7 +13,7 @@ type Props = {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   onSearch: () => void
   events: EventType[]
-  pagination: any
+  pagination: PaginationType
   onPageChange: (p: number) => void
 }
 

--- a/src/app/event/_services/actions.ts
+++ b/src/app/event/_services/actions.ts
@@ -2,7 +2,7 @@
 
 import { fetchSSR } from '@/app/_global/libs/utils'
 import type CommonSearchType from '@/app/_global/types/CommonSearchType'
-import type { EventListDataType } from '../_types'
+import type { EventListDataType, EventType } from '../_types'
 
 export async function getEvents(
   search: CommonSearchType = {},
@@ -37,7 +37,7 @@ export async function getEvents(
   }
 }
 
-export async function getEvent(hash: string) {
+export async function getEvent(hash: string): Promise<EventType | null> {
   try {
     const res = await fetchSSR(`/events/${hash}`)
     if (res.ok) {

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -7,7 +7,7 @@ export default async function EventPage({
   searchParams,
 }: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
-}) {
+}): Promise<JSX.Element> {
   const params = await searchParams
   const search: CommonSearchType = {
     page: Number(params?.page as string) || 1,


### PR DESCRIPTION
## Summary
- add explicit return type for `getEvent` server action
- type Event list pagination and route params for event pages

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb1858dd8833183d00a51fc7c6880