### PR TITLE
feat: show notice modal on main page

### DIFF
--- a/src/app/_components/NoticeModal.tsx
+++ b/src/app/_components/NoticeModal.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React, { useState } from 'react'
+import Image from 'next/image'
+import styled from 'styled-components'
+import LayerPopup from '../_global/components/LayerPopup'
+import type { BoardDataType } from '@/app/board/_types/BoardType'
+
+const List = styled.ul`
+  margin-top: 20px;
+  li + li {
+    margin-top: 10px;
+  }
+  a {
+    text-decoration: none;
+    color: #333;
+  }
+`
+
+type Props = {
+  items?: Array<BoardDataType>
+}
+
+const NoticeModal = ({ items }: Props) => {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <LayerPopup isOpen={open} onClose={() => setOpen(false)} width={500}>
+      <Image src="/globe.svg" alt="guide" width={480} height={240} />
+      <List>
+        {items?.map((item) => (
+          <li key={item.seq}>
+            <a href={`/board/view/${item.seq}`}>{item.subject}</a>
+          </li>
+        ))}
+      </List>
+    </LayerPopup>
+  )
+}
+
+export default React.memo(NoticeModal)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
+import NoticeModal from './_components/NoticeModal'
+import { getList } from '@/app/board/_services/boardData'
 
-export default function MainPage() {
-
-  return <></>
+export default async function MainPage() {
+  const { items } = await getList('notice', { limit: 5 })
+  return <NoticeModal items={items} />
 }


### PR DESCRIPTION
## Summary
- display a modal on the main page with a guide image
- list the latest five notice posts inside the modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b015a3317883319b30af850e70c2ae